### PR TITLE
craft_baseline 완성

### DIFF
--- a/craft/modules/original_test.ipynb
+++ b/craft/modules/original_test.ipynb
@@ -386,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 73,
    "id": "e0c4c10c-f3a7-4732-aeaa-c22d8c20ae59",
    "metadata": {},
    "outputs": [
@@ -394,12 +394,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "infer/postproc time : 0.352/0.0162학기\\캡스톤\\Baram_Handwritting_Analysis\\craft\\common\\images\\test.png\n",
-      "infer/postproc time : 0.143/0.0022학기\\캡스톤\\Baram_Handwritting_Analysis\\craft\\common\\images\\test2.png\n",
-      "infer/postproc time : 0.278/0.0092학기\\캡스톤\\Baram_Handwritting_Analysis\\craft\\common\\images\\test3.png\n",
-      "infer/postproc time : 0.118/0.0022학기\\캡스톤\\Baram_Handwritting_Analysis\\craft\\common\\images\\test4.png\n",
+      "infer/postproc time : 0.282/0.0102학기\\캡스톤\\Baram_Handwritting_Analysis\\craft\\common\\images\\test.png\n",
+      "infer/postproc time : 0.123/0.0022학기\\캡스톤\\Baram_Handwritting_Analysis\\craft\\common\\images\\test2.png\n",
+      "infer/postproc time : 0.268/0.0012학기\\캡스톤\\Baram_Handwritting_Analysis\\craft\\common\\images\\test3.png\n",
+      "infer/postproc time : 0.129/0.0022학기\\캡스톤\\Baram_Handwritting_Analysis\\craft\\common\\images\\test4.png\n",
       "\n",
-      "Elapsed time : 0.997s\n"
+      "Elapsed time : 0.848s\n"
      ]
     }
    ],


### PR DESCRIPTION
기존 CRAFT의 test.py를 ipynb기반의 파일로 수정하고 일부 코드를 파이썬 버전에 맞게 변경하였음

![res_test3](https://github.com/user-attachments/assets/497041c9-a3d9-46af-91e1-ccb8c979d5b1)
글씨 범위를 인식하고

[4,9,212,9,212,58,4,58] 각 box의 꼭지점 좌표를 반환하고

![res_test3_mask](https://github.com/user-attachments/assets/dc79cc90-5026-4106-9f8b-0d035e67cde5)
글씨 중심일 가능성이 높은 포인트와, 글씨의 연결점이 될 가능성이 높은 포인트를 인식하여 히트맵으로 만든다